### PR TITLE
Part of trtllm worker graceful shutdown fix

### DIFF
--- a/deploy/dynamo/sdk/src/dynamo/sdk/cli/serving.py
+++ b/deploy/dynamo/sdk/src/dynamo/sdk/cli/serving.py
@@ -147,6 +147,7 @@ def _create_watcher(name, args, numprocesses, working_dir, env):
         graceful_timeout=86400,
         use_sockets=True,
         stop_children=False,
+        copy_env=True,
     )
 
 


### PR DESCRIPTION
#### Overview:

Allow for graceful shutdown.

#### Details:

BentoML does stop_children True by default. This means when the worker process tries to handle sigterm to do graceful shutdown it doesn't have full control. For the trtllm worker for example all child processes automatically receive the term sigal and this interferes with ongoing requests. In this PR we do two things:
1. Do not stop_children via watcher.
2. Kill child processes explicitly after graceful shutdown.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
