### PR TITLE
Mf/fix error parsing

### DIFF
--- a/lib/bindings/python/examples/openai_service/curl.py
+++ b/lib/bindings/python/examples/openai_service/curl.py
@@ -75,7 +75,7 @@ for stream in [True, False, False, True]:
             }
         ],
         "max_tokens": 64,
-        "stream": True,
+        "stream": stream,
         "temperature": 0.7,
         "top_p": 0.9,
         "frequency_penalty": 0.1,
@@ -89,8 +89,9 @@ for stream in [True, False, False, True]:
             for line in response.iter_lines():
                 if line and not line.startswith(b"data: [DONE]"):
                     try:
-                        json_line = json.loads(line)
+                        json_line = json.loads(line[len(b"data: "):])
                         response_agg += json_line["choices"][0]["delta"]["content"]
+                        
                     except json.JSONDecodeError:
                         print("Error decoding JSON:", line)
         else:

--- a/lib/bindings/python/examples/openai_service/curl.py
+++ b/lib/bindings/python/examples/openai_service/curl.py
@@ -63,32 +63,38 @@ headers = {
     "accept": "application/json",
     "Content-Type": "application/json"
 }
-data = {
-    "model": "mock_model",
-    "messages": [
-        {
-            "role": "user",
-            "content": "Hello! How are you?"
-        }
-    ],
-    "max_tokens": 64,
-    "stream": True,
-    "temperature": 0.7,
-    "top_p": 0.9,
-    "frequency_penalty": 0.1,
-    "presence_penalty": 0.2,
-    "top_k": 5
-}
-response = requests.post(url, headers=headers, data=json.dumps(data), stream=True)
-if response.status_code == 200:
-    response_agg = ""
-    for line in response.iter_lines():
-        if line and not line.startswith(b"data: [DONE]"):
-            try:
-                json_line = json.loads(line)
-                response_agg += json_line["choices"][0]["delta"]["content"]
-            except json.JSONDecodeError:
-                print("Error decoding JSON:", line)
-    print("Response:", response_agg)
-else:
-    print("Error:", response.status_code, response.text)
+
+for stream in [True, False, False, True]:
+    print(f"### Stream: {stream}")
+    data = {
+        "model": "mock_model",
+        "messages": [
+            {
+                "role": "user",
+                "content": "Hello! How are you?"
+            }
+        ],
+        "max_tokens": 64,
+        "stream": True,
+        "temperature": 0.7,
+        "top_p": 0.9,
+        "frequency_penalty": 0.1,
+        "presence_penalty": 0.2,
+        "top_k": 5
+    }
+    response = requests.post(url, headers=headers, data=json.dumps(data), stream=True)
+    if response.status_code == 200:
+        if stream:
+            response_agg = ""
+            for line in response.iter_lines():
+                if line and not line.startswith(b"data: [DONE]"):
+                    try:
+                        json_line = json.loads(line)
+                        response_agg += json_line["choices"][0]["delta"]["content"]
+                    except json.JSONDecodeError:
+                        print("Error decoding JSON:", line)
+        else:
+            response_agg = response.text
+        print("Response:", response_agg)
+    else:
+        print("Error:", response.status_code, response.text)

--- a/lib/bindings/python/examples/openai_service/server.py
+++ b/lib/bindings/python/examples/openai_service/server.py
@@ -39,6 +39,8 @@ class MockEngine:
 
         async def generator():
             num_chunks = 5
+            if self.counter % 2 == 0:
+                raise HttpError(415 + self.counter, 'bad luck, your schema got rejected')
             for i in range(num_chunks):
                 mock_content = f"chunk{i}"
                 finish_reason = "stop" if (i == num_chunks - 1) else None

--- a/lib/bindings/python/examples/openai_service/server.py
+++ b/lib/bindings/python/examples/openai_service/server.py
@@ -30,8 +30,7 @@ class MockEngine:
 
     def generate(self, request, py_context):
         self.counter += 1
-        if self.counter % 2 == 0:
-            raise HttpError(415 + self.counter, 'bad luck, your schema got rejected')
+       
         id = f"chat-{uuid.uuid4()}"
         created = int(time.time())
         model = self.model_name

--- a/lib/bindings/python/examples/openai_service/server.py
+++ b/lib/bindings/python/examples/openai_service/server.py
@@ -51,7 +51,7 @@ class MockEngine:
                     "choices": [
                         {
                             "index": i,
-                            "delta": {"role": None, "content": mock_content},
+                            "delta": {"role": "assistant", "content": mock_content},
                             "logprobs": None,
                             "finish_reason": finish_reason,
                         }

--- a/lib/bindings/python/rust/http.rs
+++ b/lib/bindings/python/rust/http.rs
@@ -15,7 +15,7 @@
 
 use std::sync::Arc;
 
-use pyo3::{exceptions::PyException, prelude::*};
+use pyo3::prelude::*;
 
 use crate::{engine::*, to_pyerr, CancellationToken};
 use tracing::info;
@@ -27,6 +27,7 @@ pub use dynamo_runtime::{
     protocols::annotated::Annotated,
     Error, Result,
 };
+use dynamo_engine_python::HttpError;
 
 #[pyclass]
 pub struct HttpService {
@@ -94,30 +95,7 @@ impl HttpService {
     }
 }
 
-/// Python Exception for HTTP errors
-#[pyclass(extends=PyException)]
-pub struct HttpError {
-    code: u16,
-    message: String,
-}
 
-#[pymethods]
-impl HttpError {
-    #[new]
-    pub fn new(code: u16, message: String) -> Self {
-        HttpError { code, message }
-    }
-
-    #[getter]
-    fn code(&self) -> u16 {
-        self.code
-    }
-
-    #[getter]
-    fn message(&self) -> &str {
-        &self.message
-    }
-}
 
 #[pyclass]
 #[derive(Clone)]

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -30,6 +30,7 @@ use dynamo_runtime::{
     protocols::annotated::Annotated as RsAnnotated,
     traits::DistributedRuntimeProvider,
 };
+use dynamo_engine_python::HttpError;
 
 use dynamo_engine_python::PyContext;
 
@@ -78,7 +79,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<llm::billing::PyBillingPublisher>()?;
     m.add_class::<llm::billing::PyBillingEvent>()?;
     m.add_class::<http::HttpService>()?;
-    m.add_class::<http::HttpError>()?;
+    m.add_class::<HttpError>()?;
     m.add_class::<http::HttpAsyncEngine>()?;
     m.add_class::<EtcdKvCache>()?;
 
@@ -423,7 +424,7 @@ impl Endpoint {
         generator: PyObject,
         lease: Option<&PyLease>,
     ) -> PyResult<Bound<'p, PyAny>> {
-        let engine = Arc::new(engine::PythonAsyncEngine::new(
+        let engine = Arc::new(http::HttpAsyncEngine::new(
             generator,
             self.event_loop.clone(),
         )?);

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -424,7 +424,7 @@ impl Endpoint {
         generator: PyObject,
         lease: Option<&PyLease>,
     ) -> PyResult<Bound<'p, PyAny>> {
-        let engine = Arc::new(http::HttpAsyncEngine::new(
+        let engine = Arc::new(engine::PythonAsyncEngine::new(
             generator,
             self.event_loop.clone(),
         )?);

--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -29,7 +29,7 @@ from dynamo._core import DistributedRuntime as DistributedRuntime
 from dynamo._core import EtcdKvCache as EtcdKvCache
 from dynamo._core import ModelDeploymentCard as ModelDeploymentCard
 from dynamo._core import OAIChatPreprocessor as OAIChatPreprocessor
-
+from dynamo._core import HttpError
 
 def dynamo_worker(static=False):
     def decorator(func):
@@ -80,7 +80,7 @@ def dynamo_endpoint(
                     else:
                         raise ValueError(f"Invalid request: {args[pos]}, {args}")
             except ValidationError as e:
-                raise ValueError(f"Invalid request: {e}")
+                raise HttpError(400, f"Invalid request: {e}")
 
             # Wrap the async generator
             async for item in func(*args_list, **kwargs):

--- a/lib/engines/python/src/lib.rs
+++ b/lib/engines/python/src/lib.rs
@@ -123,6 +123,9 @@ pub struct HttpError {
 impl HttpError {
     #[new]
     pub fn new(code: u16, message: String) -> Self {
+        if code < 400 || code > 599 {
+            panic!("Invalid HTTP error code: {}", code);
+        }
         HttpError { code, message }
     }
 

--- a/lib/engines/python/src/lib.rs
+++ b/lib/engines/python/src/lib.rs
@@ -402,7 +402,7 @@ where
                                         code: *code,
                                         message: message.clone(),
                                     },
-                                ).unwrap();
+                                ).unwrap_or_else(|_| "{\"code\":500,\"message\":\"Internal Server Error HTTP Serialize\"}".to_string());
                                 Annotated::with_http_error(msg, serde_http)
                             }
                         };

--- a/lib/engines/python/src/lib.rs
+++ b/lib/engines/python/src/lib.rs
@@ -397,7 +397,7 @@ where
                             }
                             ResponseProcessingError::HttpException { code, message } => {
                                 let msg = format!(
-                                    "python has raised an http error: {}: {}",
+                                    "HTTPExceptionDetected: {}: {}",
                                     code, message
                                 );
                                 let serde_http = serde_json::to_string(

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -16,10 +16,10 @@
 #![allow(clippy::module_inception)]
 use std::error;
 
-use thiserror::Error;
-use serde::{Deserialize, Serialize};
-use axum::response::{IntoResponse, Response};
 use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use tracing::warn;
 
 #[derive(Debug, Error)]
@@ -49,6 +49,10 @@ impl IntoResponse for HttpError {
             warn!("Invalid HTTP error code: {} {}", self.code, &self.message);
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
-        (StatusCode::from_u16(self.code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR), self.message).into_response()
+        (
+            StatusCode::from_u16(self.code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+            self.message,
+        )
+            .into_response()
     }
 }

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -13,7 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::module_inception)]
+use std::error;
+
 use thiserror::Error;
+use serde::{Deserialize, Serialize};
+use axum::response::{IntoResponse, Response};
+use axum::http::StatusCode;
+use tracing::warn;
 
 #[derive(Debug, Error)]
 pub enum ServiceHttpError {
@@ -27,9 +34,21 @@ pub enum ServiceHttpError {
 /// Implementation of the Completion Engines served by the HTTP service should
 /// map their custom errors to to this error type if they wish to return error
 /// codes besides 500.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 #[error("HTTP Error {code}: {message}")]
 pub struct HttpError {
     pub code: u16,
     pub message: String,
+}
+
+impl IntoResponse for HttpError {
+    fn into_response(self) -> Response {
+        // Build the response with the given status code and JSON error body.
+        // check if code between 400 and 599
+        if self.code < 400 || self.code > 599 {
+            warn!("Invalid HTTP error code: {} {}", self.code, &self.message);
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+        (StatusCode::from_u16(self.code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR), self.message).into_response()
+    }
 }

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -222,7 +222,9 @@ impl Metrics {
         {
             // Prune to last 60 seconds
             let now = Instant::now();
-            times.retain(|(start_time, _)| now.duration_since(*start_time) <= Duration::from_secs(60));
+            times.retain(|(start_time, _)| {
+                now.duration_since(*start_time) <= Duration::from_secs(60)
+            });
             // Check again after pruning
             if times.is_empty() {
                 return (None, None);

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -293,7 +293,18 @@ async fn completions(
                     e
                 );
                 // TODO(Michael): check if HTTPError is present in the error chain and return it
-                ErrorResponse::internal_server_error("Failed to fold completions stream")
+                // todo: check if HTTPError is prsent in the error chain and return it
+                if e.to_string().contains("http error") {
+                    ErrorResponse::from_http_error(HttpError {
+                        code: 400,
+                        message: e.to_string(),
+                    })
+                }  else {
+                    ErrorResponse::internal_server_error(&format!(
+                        "Failed to fold chat completions stream: {}",
+                        e
+                    ))
+                }
             })?;
         guard.defuse();
         inflight.mark_ok();
@@ -398,11 +409,19 @@ async fn chat_completions(
                     request_id,
                     e
                 );
+
                 // todo: check if HTTPError is prsent in the error chain and return it
-                ErrorResponse::internal_server_error(&format!(
-                    "Failed to fold chat completions stream: {}",
-                    e
-                ))
+                if e.to_string().contains("http error") {
+                    ErrorResponse::from_http_error(HttpError {
+                        code: 400,
+                        message: e.to_string(),
+                    })
+                }  else {
+                    ErrorResponse::internal_server_error(&format!(
+                        "Failed to fold chat completions stream: {}",
+                        e
+                    ))
+                }
             })?;
         guard.defuse();
         inflight.mark_ok();

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -259,6 +259,7 @@ async fn completions(
                     request_id,
                     e
                 );
+                // TODO(Michael): check if HTTPError is present in the error chain and return it
                 ErrorResponse::internal_server_error("Failed to fold completions stream")
             })?;
 
@@ -363,6 +364,7 @@ async fn chat_completions(
                     request_id,
                     e
                 );
+                // todo: check if HTTPError is prsent in the error chain and return it
                 ErrorResponse::internal_server_error(&format!(
                     "Failed to fold chat completions stream: {}",
                     e

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -294,7 +294,7 @@ async fn completions(
                 );
                 // TODO(Michael): check if HTTPError is present in the error chain and return it
                 // todo: check if HTTPError is prsent in the error chain and return it
-                if e.to_string().contains("http error") {
+                if e.to_string().contains("HTTPExceptionDetected") {
                     ErrorResponse::from_http_error(HttpError {
                         code: 400,
                         message: e.to_string(),
@@ -411,7 +411,7 @@ async fn chat_completions(
                 );
 
                 // todo: check if HTTPError is prsent in the error chain and return it
-                if e.to_string().contains("http error") {
+                if e.to_string().contains("HTTPExceptionDetected") {
                     ErrorResponse::from_http_error(HttpError {
                         code: 400,
                         message: e.to_string(),

--- a/lib/llm/src/protocols/codec.rs
+++ b/lib/llm/src/protocols/codec.rs
@@ -23,13 +23,13 @@
 // TODO: Determine if we should use an External EventSource crate. There appear to be several
 // potential candidates.
 
+use super::Annotated;
 use bytes::BytesMut;
 use futures::Stream;
 use serde::Deserialize;
 use std::{io::Cursor, pin::Pin};
 use tokio_util::codec::{Decoder, FramedRead, LinesCodec};
 use tracing::error;
-use super::Annotated;
 
 /// An error that occurs when decoding an SSE stream.
 #[derive(Debug, thiserror::Error)]
@@ -120,7 +120,6 @@ where
             id: value.id,
             event: value.event,
             comment: value.comments,
-
         })
     }
 }

--- a/lib/llm/src/protocols/codec.rs
+++ b/lib/llm/src/protocols/codec.rs
@@ -28,7 +28,7 @@ use futures::Stream;
 use serde::Deserialize;
 use std::{io::Cursor, pin::Pin};
 use tokio_util::codec::{Decoder, FramedRead, LinesCodec};
-
+use tracing::error;
 use super::Annotated;
 
 /// An error that occurs when decoding an SSE stream.
@@ -103,6 +103,7 @@ where
                     Some(comments) => comments.join("\n"),
                     None => "`event: error` detected, but no error message found".to_string(),
                 };
+                error!("Custommm: Error event detected: {}", message);
                 return Err(message);
             }
         }
@@ -119,6 +120,7 @@ where
             id: value.id,
             event: value.event,
             comment: value.comments,
+
         })
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -23,8 +23,8 @@ use async_openai::types::{ChatCompletionMessageToolCall, ChatCompletionToolType,
 use futures::{Stream, StreamExt};
 use std::{
     collections::{BTreeMap, HashMap},
-    pin::Pin,
     convert::TryFrom,
+    pin::Pin,
 };
 
 /// A type alias for a pinned, dynamically-dispatched stream that is `Send` and `Sync`.
@@ -229,7 +229,8 @@ impl DeltaAggregator {
         // Collect results, propagating the first error if any
         let mut choices: Vec<async_openai::types::ChatChoice> = choices_results
             .into_iter()
-            .collect::<Result<Vec<_>, String>>()?;
+            .collect::<Result<Vec<_>, String>>(
+        )?;
 
         choices.sort_by(|a, b| a.index.cmp(&b.index));
 

--- a/lib/runtime/src/protocols/annotated.rs
+++ b/lib/runtime/src/protocols/annotated.rs
@@ -51,9 +51,7 @@ impl<R> Annotated<R> {
         }
     }
 
-    pub fn with_http_error(
-        error: String, error_http: String, 
-    ) -> Self {
+    pub fn with_http_error(error: String, error_http: String) -> Self {
         Self {
             data: None,
             id: None,

--- a/lib/runtime/src/protocols/annotated.rs
+++ b/lib/runtime/src/protocols/annotated.rs
@@ -51,6 +51,17 @@ impl<R> Annotated<R> {
         }
     }
 
+    pub fn with_http_error(
+        error: String, error_http: String, 
+    ) -> Self {
+        Self {
+            data: None,
+            id: None,
+            event: Some("error".to_string()),
+            comment: Some(vec![error, error_http]),
+        }
+    }
+
     /// Create a new annotated stream from the given data
     pub fn from_data(data: R) -> Self {
         Self {


### PR DESCRIPTION
[#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

Bit of a large PR:
- allows to raise HTTPError in python. This is propagated to the user. E.g. pydantic errors are part of this by default
- allows canceling the request immediately. So far not done for non-streaming. 
- propagates the HTTPError across devices

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
](basetenlabs:mf/fix-error-parsing)