### PR TITLE
remove-newline-in-error

### DIFF
--- a/lib/bindings/python/examples/openai_service/server.py
+++ b/lib/bindings/python/examples/openai_service/server.py
@@ -38,9 +38,11 @@ class MockEngine:
 
         async def generator():
             num_chunks = 5
-            if self.counter % 2 == 0:
-                raise HttpError(415 + self.counter, 'bad luck, your schema got rejected')
+            # if self.counter % 2 == 0:
+            #     raise HttpError(415 + self.counter, 'bad luck, your schema got rejected')
             for i in range(num_chunks):
+                if self.counter % 3 == 0 and i > 1:
+                    raise HttpError(415 + self.counter, 'bad luck, your schema got rejected during streaming\n')
                 mock_content = f"chunk{i}"
                 finish_reason = "stop" if (i == num_chunks - 1) else None
                 chunk = {

--- a/lib/bindings/python/rust/http.rs
+++ b/lib/bindings/python/rust/http.rs
@@ -18,16 +18,16 @@ use std::sync::Arc;
 use pyo3::prelude::*;
 
 use crate::{engine::*, to_pyerr, CancellationToken};
-use tracing::info;
 pub use dynamo_llm::http::service::{error as http_error, service_v2};
+use tracing::info;
 
+use dynamo_engine_python::HttpError;
 pub use dynamo_runtime::{
     error,
     pipeline::{async_trait, AsyncEngine, Data, ManyOut, SingleIn},
     protocols::annotated::Annotated,
     Error, Result,
 };
-use dynamo_engine_python::HttpError;
 
 #[pyclass]
 pub struct HttpService {
@@ -95,8 +95,6 @@ impl HttpService {
     }
 }
 
-
-
 #[pyclass]
 #[derive(Clone)]
 pub struct HttpAsyncEngine(pub PythonAsyncEngine);
@@ -147,7 +145,10 @@ where
                             .into_value(py)
                             .extract::<PyRef<HttpError>>(py)
                         {
-                            info!("Raising HttpError {}: {}", http_error_instance.code, http_error_instance.message);
+                            info!(
+                                "Raising HttpError {}: {}",
+                                http_error_instance.code, http_error_instance.message
+                            );
                             Err(http_error::HttpError {
                                 code: http_error_instance.code,
                                 message: http_error_instance.message.clone(),

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -24,13 +24,13 @@ use rs::pipeline::network::Ingress;
 use std::{fmt::Display, sync::Arc};
 use tokio::sync::Mutex;
 
+use dynamo_engine_python::HttpError;
 use dynamo_runtime::{
     self as rs, logging,
     pipeline::{AsyncEngineContextProvider, EngineStream, ManyOut, SingleIn},
     protocols::annotated::Annotated as RsAnnotated,
     traits::DistributedRuntimeProvider,
 };
-use dynamo_engine_python::HttpError;
 
 use dynamo_engine_python::PyContext;
 

--- a/lib/bindings/python/rust/llm/billing.rs
+++ b/lib/bindings/python/rust/llm/billing.rs
@@ -1,9 +1,9 @@
-use pyo3::prelude::*;
-use pyo3::exceptions::PyRuntimeError;
-use serde::{Deserialize, Serialize};
-use chrono::Utc;
 use super::*;
+use chrono::Utc;
 use llm_rs::billing::{BillingEvent, BillingPublisher};
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use serde::{Deserialize, Serialize};
 
 #[pyclass]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -20,7 +20,14 @@ pub struct PyBillingEvent {
 impl PyBillingEvent {
     #[pyo3(signature = (output_tokens, input_tokens, organization_id, request_id, billing_model_version, model_name=None))]
     #[new]
-    pub fn new(output_tokens: i32, input_tokens: i32, organization_id: String, request_id: String, billing_model_version: String, model_name: Option<String>) -> Self {
+    pub fn new(
+        output_tokens: i32,
+        input_tokens: i32,
+        organization_id: String,
+        request_id: String,
+        billing_model_version: String,
+        model_name: Option<String>,
+    ) -> Self {
         Self {
             output_tokens,
             input_tokens,


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:
```
docker-processor-1          |   File "/usr/local/lib/python3.12/dist-packages/pydantic/main.py", line 627, in model_validate
docker-processor-1          |     return cls.__pydantic_validator__.validate_python(
docker-processor-1          |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
docker-processor-1          | pydantic_core._pydantic_core.ValidationError: 1 validation error for DynamoTRTLLMChatCompletionRequest
docker-processor-1          |   Value error, Only support one response per prompt without beam search [type=value_error, input_value={'m
ax_tokens': 64, 'messa... 1.0, 'seed': 681879655}, input_type=dict]
docker-processor-1          |     For further information visit https://errors.pydantic.dev/2.10/v/value_error
docker-processor-1          | 
docker-processor-1          | During handling of the above exception, another exception occurred:
docker-processor-1          | 
docker-processor-1          | Traceback (most recent call last):
docker-processor-1          |   File "/usr/local/lib/python3.12/dist-packages/dynamo/runtime/__init__.py", line 83, in wrapper
docker-processor-1          |     raise ValueError(f"Invalid request: {e}")
docker-processor-1          | ValueError: Invalid request: 1 validation error for DynamoTRTLLMChatCompletionRequest
docker-processor-1          |   Value error, Only support one response per prompt without beam search [type=value_error, input_value={'m
ax_tokens': 64, 'messa... 1.0, 'seed': 681879655}, input_type=dict]
docker-processor-1          |     For further information visit https://errors.pydantic.dev/2.10/v/value_error
docker-frontend-1           | 
docker-frontend-1           | thread 'tokio-runtime-worker' panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/a
xum-0.8.1/src/response/sse.rs:363:9:
docker-frontend-1           | assertion `left == right` failed: SSE field value cannot contain newlines or carriage returns
docker-frontend-1           |   left: Some(153)
docker-frontend-1           |  right: None
```

Newlines get streamed to SSE -> leading to issues in frontend.

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes GitHub issue: #xxx
