### PR TITLE
Clean up user-facing error message from Pydantic validation errors

### DIFF
--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -31,6 +31,7 @@ from dynamo._core import ModelDeploymentCard as ModelDeploymentCard
 from dynamo._core import OAIChatPreprocessor as OAIChatPreprocessor
 from dynamo._core import HttpError
 
+
 def dynamo_worker(static=False):
     def decorator(func):
         @wraps(func)
@@ -83,7 +84,7 @@ def dynamo_endpoint(
                 errors = exc.errors()
                 message = "Invalid request"
                 if len(errors) > 0:
-                    message = f"{errors[0]['loc'][0]}: {errors[0]['msg']}"
+                    message = ", ".join(format_message(error) for error in errors)
                 raise HttpError(400, message)
 
             # Wrap the async generator
@@ -98,3 +99,11 @@ def dynamo_endpoint(
         return wrapper
 
     return decorator
+
+
+def format_message(error: dict[str, Any]) -> str:
+    """Format Pydantic error message for display."""
+    location = ".".join(error["loc"])
+    input = error["input"]
+    msg = error["msg"]
+    return f"{location} ({input}): {msg}"

--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -79,8 +79,12 @@ def dynamo_endpoint(
                         args_list[pos] = request_model.parse_obj(args[pos])
                     else:
                         raise ValueError(f"Invalid request: {args[pos]}, {args}")
-            except ValidationError as e:
-                raise HttpError(400, str(e.json()))
+            except ValidationError as exc:
+                errors = exc.errors()
+                message = "Invalid request"
+                if len(errors) > 0:
+                    message = f"{errors[0]['loc'][0]}: {errors[0]['msg']}"
+                raise HttpError(400, message)
 
             # Wrap the async generator
             async for item in func(*args_list, **kwargs):


### PR DESCRIPTION
#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
For Pydantic ValidationErrors, such as the ones generated by adding `Field(ge=0, le=1)`, we're still outputting error messages that give too much information and could be more user friendly:
```json
{
  "error": "[{\"type\":\"less_than_equal\",\"loc\":[\"temperature\"],\"msg\":\"Input should be less than or equal to 4\",\"input\":10.0,\"ctx\":{\"le\":4.0},\"url\":\"https://errors.pydantic.dev/2.10/v/less_than_equal\"}]"
}
```
We also have an inconsistency where Pydantic validation done using the `@model_validator` decorator outputs the exact string in the `HttpError`.

With this change, the error output is the same in either case and is simply:
```json
{"error": "temperature (10.0): Input should be less than or equal to 4"}
```

If there are multiple errors, they are displayed in a comma separated list:
```json
{"error":"temperature (1000.0): Input should be less than or equal to 4, top_p (3.0): Input should be less than or equal to 1"}
```

#### Details:

<!-- Describe the changes made in this PR. -->
Changes the text content for the 400 HTTP error returned on Pydantic ValidationErrors. This was tested by building the dynamo Docker container, running it under `cache_aware_routing_trtllm`, and running queries against it that fail various validations.

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->
N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

N/A
